### PR TITLE
Updates plugin URI to point to Wordpress instead of ran.ge

### DIFF
--- a/pull-quotes.php
+++ b/pull-quotes.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Pull Quotes
- * Plugin URI: http://ran.ge
+ * Plugin URI: http://aarondcampbell.com/wordpress-plugin/pull-quotes/
  * Description: Pull Quotes done right
  * Version: 1.0.1
  * Author: Aaron D. Campbell


### PR DESCRIPTION
Having the ran.ge URI in the plugin information means that when a user
clicks on the `Visit plugin site` they are taken to http://ran.ge
instead of the actual Wordpress site with the plugin information.

![ran.ge](http://dl.dropbox.com/u/12554984/ea04.png)

Ideally clicking the link above would take to the page bellow, which contains plugin information (version, compatibility etc.)
![wordpress](http://dl.dropbox.com/u/12554984/8082.png)
